### PR TITLE
Add .PHONY declaration incase target 'LIB' is confused with directory…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+.PHONY: default ALL LIB cleanall rundir
+
 default : ALL
 
 include build/Makefile.def


### PR DESCRIPTION
MacOS is not case-sensitive, so it is required to declare 'LIB' as PHONY to avoid the confusion between the 'LIB' target and the local 'lib/' directory.